### PR TITLE
Fix processing of performance data

### DIFF
--- a/check_curl
+++ b/check_curl
@@ -491,7 +491,7 @@ if ($Pocet > 1) {
 
 
     if ($InludePerf)
-        $message .= " time=$Time size=$Size\n";
+        $message .= " |time=$Time size=$Size\n";
 
     echo $message;
 


### PR DESCRIPTION
Nagios/Icinga data processed by Graphite will not write out correctly unless there is a `|` character after the string output.

Reference: https://icinga.com/docs/icinga2/latest/doc/05-service-monitoring/#performance-data-metrics
```
Graphs assembling process record
+ Icinga check command: 'check-solr-prod'
+ Obscured check command: NULL
+ Applying templates for check command 'check-solr-prod'
+ Applying default templates, excluding previously used metrics
++ Not applying template 'default-host'
++ Applying template 'default-service'
+++ Fetched 1 metric(s) from 'http://icinga-prod-graphite-01:443/metrics/expand?query=icinga2.HOST_geisinger_edu.services.check-solr-prod.check-solr-prod.perfdata.%2A.value'
+++ Excluded 0 metric(s)
+++ Combined 1 metric(s) to 1 chart(s)
````